### PR TITLE
Add visual prompt tuning support for YOLOE text prompts

### DIFF
--- a/predict_text_prompt.py
+++ b/predict_text_prompt.py
@@ -1,7 +1,10 @@
 import argparse
 import os
+
+import torch
 from PIL import Image
 import supervision as sv
+
 from ultralytics import YOLOE
 
 
@@ -11,30 +14,59 @@ def parse_args():
         "--source",
         type=str,
         required=True,
-        help="Path to the input image"
+        help="Path to the input image",
     )
     parser.add_argument(
         "--checkpoint",
         type=str,
         default="yoloe-v8l-seg.pt",
-        help="Path or ID of the model checkpoint"
+        help="Path or ID of the model checkpoint",
     )
     parser.add_argument(
         "--names",
         nargs="+",
         default=["person"],
-        help="List of class names to set for the model"
+        help="List of class names to set for the model",
     )
     parser.add_argument(
         "--output",
         type=str,
-        help="Path to save the annotated image"
+        help="Path to save the annotated image",
     )
     parser.add_argument(
         "--device",
         type=str,
         default="cpu",
-        help="Device to run inference on"
+        help="Device to run inference on",
+    )
+    parser.add_argument(
+        "--prompt-image",
+        type=str,
+        help="Optional visual prompt image used to tune text embeddings online",
+    )
+    parser.add_argument(
+        "--prompt-boxes",
+        type=float,
+        nargs="+",
+        help="Bounding boxes for the prompt image (x1 y1 x2 y2 per class)",
+    )
+    parser.add_argument(
+        "--prompt-format",
+        type=str,
+        default="xyxy",
+        choices=["xyxy", "xywh"],
+        help="Format of the provided prompt boxes",
+    )
+    parser.add_argument(
+        "--prompt-normalized",
+        action="store_true",
+        help="Indicate that prompt boxes are already normalized to [0, 1]",
+    )
+    parser.add_argument(
+        "--support-size",
+        type=int,
+        default=None,
+        help="Override the support crop resolution used for visual prompt tuning",
     )
     return parser.parse_args()
 
@@ -51,7 +83,24 @@ def main():
     model = YOLOE(args.checkpoint)
     model.to(args.device)
 
-    model.set_classes(args.names, model.get_text_pe(args.names))
+    if args.prompt_image:
+        if not args.prompt_boxes:
+            raise ValueError("--prompt-boxes must be provided when using --prompt-image.")
+        prompt_image = Image.open(args.prompt_image).convert("RGB")
+        box_values = torch.tensor(args.prompt_boxes, dtype=torch.float32).view(-1, 4)
+        if box_values.shape[0] != len(args.names):
+            raise ValueError("Number of prompt boxes must match the number of class names.")
+        model.tune_text_prompt(
+            visual_prompt=prompt_image,
+            boxes=box_values,
+            class_names=args.names,
+            box_format=args.prompt_format,
+            normalized=args.prompt_normalized,
+            support_size=args.support_size,
+        )
+    else:
+        model.set_classes(args.names, model.get_text_pe(args.names))
+
     results = model.predict(image, verbose=False)
 
     detections = sv.Detections.from_ultralytics(results[0])
@@ -68,20 +117,21 @@ def main():
     annotated_image = image.copy()
     annotated_image = sv.MaskAnnotator(
         color_lookup=sv.ColorLookup.INDEX,
-        opacity=0.4
+        opacity=0.4,
     ).annotate(scene=annotated_image, detections=detections)
     annotated_image = sv.BoxAnnotator(
         color_lookup=sv.ColorLookup.INDEX,
-        thickness=thickness
+        thickness=thickness,
     ).annotate(scene=annotated_image, detections=detections)
     annotated_image = sv.LabelAnnotator(
         color_lookup=sv.ColorLookup.INDEX,
         text_scale=text_scale,
-        smart_position=True
+        smart_position=True,
     ).annotate(scene=annotated_image, detections=detections, labels=labels)
 
     annotated_image.save(args.output)
     print(f"Annotated image saved to: {args.output}")
+
 
 if __name__ == "__main__":
     main()

--- a/predict_visual_prompt.py
+++ b/predict_visual_prompt.py
@@ -43,3 +43,7 @@ model.predict(source_image, prompts=visuals, predictor=YOLOEVPSegPredictor,
 model.set_classes(["object0", "object1"], model.predictor.vpe)
 model.predictor = None  # remove VPPredictor
 model.predict(target_image, save=True)
+
+# To tune text prompts from a single visual prompt image instead of manual arrays:
+# from PIL import Image
+# model.tune_text_prompt(Image.open(source_image), visuals["bboxes"][0], ["object0", "object1"])

--- a/train_pe.py
+++ b/train_pe.py
@@ -1,5 +1,7 @@
+from pathlib import Path
+
 from ultralytics import YOLOE
-from ultralytics.models.yolo.yoloe.train_pe import YOLOEPETrainer, YOLOEPESegTrainer
+from ultralytics.models.yolo.yoloe.train_pe import YOLOEPESegTrainer
 import os
 from ultralytics.nn.tasks import guess_model_scale
 from ultralytics.utils import yaml_load, LOGGER
@@ -22,11 +24,34 @@ LOGGER.info(f"Extends: {extends}")
 
 model = YOLOE("yoloe-v8l-seg.pt")
 
-# Ensure pe is set for classes
-names = list(yaml_load(data)['names'].values())
-tpe = model.get_text_pe(names)
-pe_path = "coco-pe.pt"
-torch.save({"names": names, "pe": tpe}, pe_path)
+# Prepare prompt tuning assets
+names = list(yaml_load(data)["names"].values())
+support_path = Path("support/coco_support.pt")
+base_tuner_state = Path("coop_states/coco_base.coop.pt")
+pe_path = Path("artifacts/coco-pe.pt")
+tuned_prompt_path = Path("artifacts/coco-tuned.coop.pt")
+pe_path.parent.mkdir(parents=True, exist_ok=True)
+tuned_prompt_path.parent.mkdir(parents=True, exist_ok=True)
+
+tuner_cfg = {}
+if base_tuner_state.exists():
+    tuner_cfg["state_path"] = str(base_tuner_state)
+
+if support_path.exists():
+    support_payload = torch.load(support_path)
+    support_crops = support_payload.get("vp_crops", support_payload)
+    class_names = support_payload.get("names", names)
+    tuned_pe, tuner = model.tune_with_visual_support(support_crops, class_names, tuner_cfg)
+    tuned_pe_cpu = tuned_pe.cpu()
+    torch.save({"names": class_names, "pe": tuned_pe_cpu}, pe_path)
+    tuner.save_state(tuned_prompt_path)
+    coop_state_for_training = str(tuned_prompt_path)
+    names = class_names
+else:
+    LOGGER.warning("Support crops not found; falling back to text prompt embeddings.")
+    tpe = model.get_text_pe(names).cpu()
+    torch.save({"names": names, "pe": tpe}, pe_path)
+    coop_state_for_training = str(base_tuner_state) if base_tuner_state.exists() else None
 
 head_index = len(model.model.model) - 1
 freeze = [str(f) for f in range(0, head_index)]
@@ -35,9 +60,27 @@ for name, child in model.model.model[-1].named_children():
         freeze.append(f"{head_index}.{name}")
 
 freeze.extend([f"{head_index}.cv3.0.0", f"{head_index}.cv3.0.1", f"{head_index}.cv3.1.0", f"{head_index}.cv3.1.1", f"{head_index}.cv3.2.0", f"{head_index}.cv3.2.1"])
-        
-model.train(data=data, epochs=10, close_mosaic=5, batch=128, 
-            optimizer='AdamW', lr0=1e-3, warmup_bias_lr=0.0, \
-            weight_decay=0.025, momentum=0.9, workers=4, \
-            device="0,1,2,3,4,5,6,7", **extends, \
-            trainer=YOLOEPESegTrainer, freeze=freeze, train_pe_path=pe_path)
+
+train_kwargs = dict(
+    data=data,
+    epochs=10,
+    close_mosaic=5,
+    batch=128,
+    optimizer="AdamW",
+    lr0=1e-3,
+    warmup_bias_lr=0.0,
+    weight_decay=0.025,
+    momentum=0.9,
+    workers=4,
+    device="0,1,2,3,4,5,6,7",
+    trainer=YOLOEPESegTrainer,
+    freeze=freeze,
+    train_pe_path=str(pe_path),
+    coop_tuner_save_path=str(tuned_prompt_path),
+    **extends,
+)
+
+if coop_state_for_training:
+    train_kwargs["coop_tuner_state"] = coop_state_for_training
+
+model.train(**train_kwargs)

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -130,3 +130,10 @@ text_model: mobileclip:blt
 text_prompt_tuner: null
 load_vp: False
 train_pe_path: None
+coop_tuner_state: null
+coop_tuner_save_path: null
+coop_tuner_steps: 200
+coop_tuner_lr: 0.001
+coop_ctx_len: 16
+coop_template: "a photo of a {}"
+coop_support_size: 224

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -2,6 +2,12 @@
 
 from pathlib import Path
 
+import numpy as np
+import torch
+from PIL import Image
+from typing import Optional
+
+from ultralytics.data.visual_prompt_utils import extract_support_crops
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo
 from ultralytics.nn.tasks import ClassificationModel, DetectionModel, OBBModel, PoseModel, SegmentationModel, YOLOEModel, YOLOESegModel
@@ -101,6 +107,97 @@ class YOLOE(Model):
     def get_visual_pe(self, img, visual):
         assert(isinstance(self.model, YOLOEModel))
         return self.model.get_visual_pe(img, visual)
+
+    @staticmethod
+    def _prepare_support_image(visual_prompt) -> torch.Tensor:
+        if isinstance(visual_prompt, torch.Tensor):
+            tensor = visual_prompt.clone()
+            if tensor.ndim == 4:
+                if tensor.shape[0] != 1:
+                    raise ValueError("Expected a single visual prompt image when providing a batched tensor.")
+                tensor = tensor.squeeze(0)
+        elif isinstance(visual_prompt, np.ndarray):
+            array = visual_prompt
+            if array.ndim == 2:
+                array = np.expand_dims(array, axis=-1)
+            tensor = torch.from_numpy(array)
+            if tensor.ndim == 2:
+                tensor = tensor.unsqueeze(0)
+            else:
+                tensor = tensor.permute(2, 0, 1)
+        elif isinstance(visual_prompt, Image.Image):
+            tensor = torch.from_numpy(np.array(visual_prompt))
+            if tensor.ndim == 2:
+                tensor = tensor.unsqueeze(-1)
+            tensor = tensor.permute(2, 0, 1)
+        else:
+            raise TypeError("visual_prompt must be a PIL image, numpy array, or torch tensor.")
+
+        if tensor.dtype != torch.float32:
+            tensor = tensor.float()
+        if tensor.max() > 1.0:
+            tensor = tensor / 255.0
+        return tensor
+
+    def tune_text_prompt(
+        self,
+        visual_prompt,
+        boxes,
+        class_names,
+        box_format: str = "xyxy",
+        normalized: bool = False,
+        support_size: Optional[int] = None,
+        tuner_cfg: Optional[dict] = None,
+    ):
+        """Tune text prompts using a single visual prompt image and bounding boxes."""
+
+        if not isinstance(self.model, YOLOEModel):
+            raise TypeError("Text prompt tuning is only supported for YOLOE models.")
+
+        image_tensor = self._prepare_support_image(visual_prompt)
+        boxes_tensor = torch.as_tensor(boxes, dtype=torch.float32)
+        if boxes_tensor.ndim != 2 or boxes_tensor.shape[1] != 4:
+            raise ValueError("boxes must have shape (N, 4).")
+        if len(class_names) != boxes_tensor.shape[0]:
+            raise ValueError("Number of class names must match number of bounding boxes.")
+
+        fmt = box_format.lower()
+        if fmt not in {"xyxy", "xywh"}:
+            raise ValueError("box_format must be either 'xyxy' or 'xywh'.")
+
+        boxes_tensor = boxes_tensor.clone()
+        if fmt == "xyxy":
+            x1, y1, x2, y2 = boxes_tensor.unbind(dim=1)
+            cx = (x1 + x2) / 2
+            cy = (y1 + y2) / 2
+            bw = x2 - x1
+            bh = y2 - y1
+        else:
+            cx, cy, bw, bh = boxes_tensor.unbind(dim=1)
+
+        if not normalized:
+            height, width = image_tensor.shape[1:]
+            cx = cx / width
+            cy = cy / height
+            bw = bw / width
+            bh = bh / height
+
+        normalized_boxes = torch.stack([cx, cy, bw, bh], dim=1)
+        crop_size = support_size or getattr(self.model.args, "coop_support_size", 224)
+        support_crops, _ = extract_support_crops(image_tensor, normalized_boxes, int(crop_size))
+        labels = torch.arange(len(class_names), dtype=torch.long)
+        support_payload = {"images": support_crops, "cls": labels}
+
+        tuned_pe, tuner = self.model.tune_with_visual_support(
+            support_payload,
+            class_names,
+            tuner_cfg or {},
+        )
+
+        if self.predictor:
+            self.predictor.model.names = self.model.names
+
+        return tuned_pe, tuner
 
     def set_vocab(self, vocab, names):
         assert(isinstance(self.model, YOLOEModel))

--- a/ultralytics/models/yolo/yoloe/train_pe.py
+++ b/ultralytics/models/yolo/yoloe/train_pe.py
@@ -1,5 +1,8 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
 from ultralytics.models.yolo.yoloe.train_yoloe import YOLOETrainerFromScratch, YOLOETrainer
 from ultralytics.models.yolo.detect import DetectionTrainer
 from ultralytics.models.yolo.segment import SegmentationTrainer
@@ -8,10 +11,20 @@ import torch
 from ultralytics.models.yolo.detect import DetectionValidator
 from copy import copy
 from ultralytics.nn.tasks import YOLOEModel, YOLOESegModel
-from ultralytics.utils import DEFAULT_CFG, RANK
+from ultralytics.utils import DEFAULT_CFG, RANK, LOGGER
+from ultralytics.utils.torch_utils import de_parallel
 
 class YOLOEPETrainer(DetectionTrainer):
-    
+
+    def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
+        super().__init__(cfg, overrides, _callbacks)
+        self._prompt_tuned = False
+        self._head_prepared = False
+        self._coop_tuner: Optional[Any] = None
+        save_target = getattr(self.args, "coop_tuner_save_path", None)
+        self._coop_tuner_save_path = Path(save_target) if save_target else self.wdir / "tuned_prompt.coop.pt"
+        self.add_callback("on_train_end", lambda _: self._save_tuned_prompt())
+
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Return YOLOEModel initialized with specified config and weights."""
         model = YOLOEModel(
@@ -20,26 +33,128 @@ class YOLOEPETrainer(DetectionTrainer):
             nc=self.data["nc"],
             verbose=verbose and RANK == -1,
         )
-        
+
         del model.model[-1].savpe
-        
+
         if weights:
             model.load(weights)
-        
+
         model.eval()
-        pe_state = torch.load(self.args.train_pe_path)
-        model.set_classes(pe_state["names"], pe_state["pe"])
-        model.model[-1].fuse(model.pe)
-        model.model[-1].cv3[0][2] = deepcopy(model.model[-1].cv3[0][2]).requires_grad_(True)
-        model.model[-1].cv3[1][2] = deepcopy(model.model[-1].cv3[1][2]).requires_grad_(True)
-        model.model[-1].cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
-        del model.pe
-        model.train()
-        
+        self._head_prepared = False
+        names = self._get_class_names()
+        if names:
+            model.names = names
+
+        tuner_state = getattr(self.args, "coop_tuner_state", None)
+        if tuner_state is not None:
+            tuner_cfg = self._build_tuner_cfg()
+            model.set_classes(names, tuner_state=tuner_state, tuner_cfg=tuner_cfg)
+            self._prompt_tuned = True
+            self._coop_tuner = getattr(model, "coop_tuner", None)
+            self._prepare_head_for_finetune(model)
+        elif self.args.train_pe_path:
+            pe_state = torch.load(self.args.train_pe_path)
+            model.set_classes(pe_state["names"], embeddings=pe_state["pe"])
+            self._prompt_tuned = True
+            self._coop_tuner = getattr(model, "coop_tuner", None)
+            self._prepare_head_for_finetune(model)
+        else:
+            self._prompt_tuned = False
+            self._head_prepared = False
+            self._coop_tuner = None
+
         return model
+
+    def _get_class_names(self) -> Sequence[str]:
+        names = self.data.get("names") if isinstance(self.data, dict) else None
+        if names is None:
+            return []
+        if isinstance(names, dict):
+            return list(names.values())
+        return list(names)
+
+    def _build_tuner_cfg(self) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {}
+        text_model = getattr(self.args, "text_model", None)
+        if text_model:
+            cfg["base_variant"] = text_model
+        ctx_len = getattr(self.args, "coop_ctx_len", None)
+        if ctx_len:
+            cfg["ctx_len"] = ctx_len
+        template = getattr(self.args, "coop_template", None)
+        if template:
+            cfg["template"] = template
+        steps = getattr(self.args, "coop_tuner_steps", None)
+        if steps is not None:
+            cfg["steps"] = steps
+        lr = getattr(self.args, "coop_tuner_lr", None)
+        if lr is not None:
+            cfg["lr"] = lr
+        tuner_state = getattr(self.args, "coop_tuner_state", None)
+        if tuner_state is not None:
+            if isinstance(tuner_state, (str, Path)):
+                cfg["state_path"] = tuner_state
+            else:
+                cfg["state"] = tuner_state
+        return cfg
+
+    def _prepare_head_for_finetune(self, model: YOLOEModel) -> None:
+        if self._head_prepared:
+            return
+        head = model.model[-1]
+        if hasattr(model, "pe"):
+            head.fuse(model.pe)
+        head.cv3[0][2] = deepcopy(head.cv3[0][2]).requires_grad_(True)
+        head.cv3[1][2] = deepcopy(head.cv3[1][2]).requires_grad_(True)
+        head.cv3[2][2] = deepcopy(head.cv3[2][2]).requires_grad_(True)
+        if hasattr(model, "pe"):
+            del model.pe
+        model.train()
+        self._head_prepared = True
+
+    def _ensure_prompt_initialized(self, batch: Dict[str, Any]) -> None:
+        if self._prompt_tuned:
+            model = de_parallel(self.model)
+            if hasattr(model, "pe") and not self._head_prepared:
+                self._prepare_head_for_finetune(model)
+            return
+
+        support = batch.get("vp_crops")
+        if not isinstance(support, dict):
+            return
+        cls_tensor = support.get("cls")
+        if not isinstance(cls_tensor, torch.Tensor) or not (cls_tensor >= 0).any():
+            return
+
+        model = de_parallel(self.model)
+        tuner_cfg = self._build_tuner_cfg()
+        names = self._get_class_names()
+        try:
+            _, tuner = model.tune_with_visual_support(support, names, tuner_cfg)
+        except ValueError as err:
+            LOGGER.warning(f"Skipping prompt tuning for current batch: {err}")
+            return
+
+        self._prompt_tuned = True
+        self._coop_tuner = tuner
+        self._prepare_head_for_finetune(model)
+
+    def _save_tuned_prompt(self) -> None:
+        model = de_parallel(self.model)
+        tuner = self._coop_tuner or getattr(model, "coop_tuner", None)
+        if tuner is None or getattr(tuner, "context", None) is None:
+            return
+        save_path = self._coop_tuner_save_path
+        tuner.save_state(save_path)
+        LOGGER.info(f"Saved tuned prompt state to {save_path}")
+
+    def preprocess_batch(self, batch):
+        batch = super().preprocess_batch(batch)
+        self._ensure_prompt_initialized(batch)
+        return batch
     
-class YOLOEPESegTrainer(SegmentationTrainer):
-    
+class YOLOEPESegTrainer(YOLOEPETrainer, SegmentationTrainer):
+
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Return YOLOEModel initialized with specified config and weights."""
         model = YOLOESegModel(
@@ -55,15 +170,29 @@ class YOLOEPESegTrainer(SegmentationTrainer):
             model.load(weights)
         
         model.eval()
-        pe_state = torch.load(self.args.train_pe_path)
-        model.set_classes(pe_state["names"], pe_state["pe"])
-        model.model[-1].fuse(model.pe)
-        model.model[-1].cv3[0][2] = deepcopy(model.model[-1].cv3[0][2]).requires_grad_(True)
-        model.model[-1].cv3[1][2] = deepcopy(model.model[-1].cv3[1][2]).requires_grad_(True)
-        model.model[-1].cv3[2][2] = deepcopy(model.model[-1].cv3[2][2]).requires_grad_(True)
-        del model.pe
-        model.train()
-        
+        self._head_prepared = False
+        names = self._get_class_names()
+        if names:
+            model.names = names
+
+        tuner_state = getattr(self.args, "coop_tuner_state", None)
+        if tuner_state is not None:
+            tuner_cfg = self._build_tuner_cfg()
+            model.set_classes(names, tuner_state=tuner_state, tuner_cfg=tuner_cfg)
+            self._prompt_tuned = True
+            self._coop_tuner = getattr(model, "coop_tuner", None)
+            self._prepare_head_for_finetune(model)
+        elif self.args.train_pe_path:
+            pe_state = torch.load(self.args.train_pe_path)
+            model.set_classes(pe_state["names"], embeddings=pe_state["pe"])
+            self._prompt_tuned = True
+            self._coop_tuner = getattr(model, "coop_tuner", None)
+            self._prepare_head_for_finetune(model)
+        else:
+            self._prompt_tuned = False
+            self._head_prepared = False
+            self._coop_tuner = None
+
         return model
 
 class YOLOEPEFreeTrainer(YOLOEPETrainer, YOLOETrainerFromScratch):


### PR DESCRIPTION
## Summary
- add CoOp prompt tuner helpers to YOLOE so visual support crops can update class embeddings and accept tuned states during prediction
- refresh the PE training workflow to run CoOp tuning from support data, respect saved tuner states, and persist tuned prompts at the end of training
- expose new prompt tuning options in the text prompt demo script and configuration defaults for easier experimentation

## Testing
- python -m compileall ultralytics/nn/prompt_tuning.py ultralytics/nn/tasks.py ultralytics/models/yolo/yoloe/train_pe.py ultralytics/models/yolo/model.py predict_text_prompt.py

------
https://chatgpt.com/codex/tasks/task_e_68da7135d6c883209e0684d410f15e6c